### PR TITLE
Lowering the ErrorRequeueTimeout from 30 seconds to 5 seconds

### DIFF
--- a/controllers/redkeycluster_manager.go
+++ b/controllers/redkeycluster_manager.go
@@ -34,7 +34,7 @@ const (
 	UpgradingDefaultTimeout   time.Duration = 30
 	ScalingDefaultTimeout     time.Duration = 30
 	ReadyRequeueTimeout       time.Duration = 30
-	ErrorRequeueTimeout       time.Duration = 30
+	ErrorRequeueTimeout       time.Duration = 5
 	MaintenanceRequeueTimeout time.Duration = 30
 )
 


### PR DESCRIPTION
**The test "up → 3" is flaky and very slow**

A simple scaling test from 0 to 3 without load cannot be more than 5 minutes.

When scaling a Redis cluster from 0 primaries to 3 primaries:

1. The Robin deployment exists with 0 replicas (scaled down when primaries were 0)
2. `handleRobinDeployment()` should detect this and scale Robin to 1 replica
3. The scale-up code at `robin.go:136-142` correctly identifies the need to scale up
4. However, before the Robin pod is ready (or possibly due to update conflicts), `doFastScaling()` tries to create a Robin client via `NewRobin()`
5. `NewRobin()` fails with "robin pod not found" because the pod hasn't started yet
6. This causes the cluster status to flip to "Error" and then back to "ScalingUp" in a loop
7. The test times out after 5 minutes waiting for the cluster to become Ready

We can fix it by doing that, NewRobin does not return an Error:

I propose a minimal fix to `doFastScaling()` in `controllers/redis_manager.go` to handle the "robin pod not found" error gracefully by requeuing without setting status to Error:

```go
// In doFastScaling, at line 859-862, change from:
redkeyRobin, err := robin.NewRobin(ctx, r.Client, redkeyCluster, logger)
if err != nil {
    r.logError(redkeyCluster.NamespacedName(), err, "Error getting Robin to check its readiness")
    return true, err  // This propagates the error and causes status=Error
}

// To:
redkeyRobin, err := robin.NewRobin(ctx, r.Client, redkeyCluster, logger)
if err != nil {
    // Robin pod may not be ready yet after scaling from 0 replicas.
    // Requeue without error to allow the pod to start.
    r.logInfo(redkeyCluster.NamespacedName(), "Robin pod not ready yet, will retry", "error", err.Error())
    return true, nil  // Requeue without error
}
```

Or, lowering the ErrorRequeueTimeout from 30 seconds to 5 seconds. Doing that reconciliation works.
