### PR TITLE
Use Robin internal cluster status

### DIFF
--- a/controllers/redis_manager.go
+++ b/controllers/redis_manager.go
@@ -1258,7 +1258,7 @@ func (r *RedkeyClusterReconciler) completeClusterScaleUp(ctx context.Context, re
 			return true, err
 		}
 		if status != redkeyv1.RobinStatusReady {
-			r.logInfo(redkeyCluster.NamespacedName(), "Waiting for Robin to end scaling up...")
+			r.logInfo(redkeyCluster.NamespacedName(), "Waiting for Robin to end scaling up...", "robin cluster status", status)
 			return true, nil // Cluster scaling not completed -> requeue
 		}
 		r.logInfo(redkeyCluster.NamespacedName(), "Robin reports cluster is ready after scaling up")


### PR DESCRIPTION
Instead of using ClusterCheck() to check the intermediate steps are done when upgrading or scaling, we now use GetClusterStatus().

ClusterCheck() can state OK status before ending a resharding or other operations, which can leads to end a step or an operation from the Operator when  the final status is not yet reached.

Using this Robin endpoint we know the internal cluster status managed by Robin, which allows to check if the command asked is completed before continuing with the next step.