### PR TITLE
Add Ready condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,34 @@ Redkey operator is built using [kubebuilder](https://github.com/kubernetes-sigs/
 
 ## Quick Start
 
+### Using Helm Charts
+
 Prerrequisites:
+
+- A running Kubernetes cluster (v1.24+)
+- kubectl (v1.24+)
+- Helm (v3.0+)(v4.0+ required for post-install hook feature in redkey-cluster chart)
+
+The project provides Helm charts to easily deploy the Redkey Operator and a sample Redkey Cluster. The charts are located in the `charts` directory of the repository.
+
+Install the Redkey Operator using the provided Helm chart:
+
+```bash
+helm install redkey-operator ./charts/redkey-operator
+```
+
+Install a sample Redkey Cluster using the provided Helm chart:
+
+```bash
+helm install my-redkey-cluster ./charts/redkey-cluster
+```
+
+Take a look at the [charts/README.md](./charts/README.md) for more details on how to use the Helm charts, including how to enable the post-install hook in the redkey-cluster chart to wait for the cluster to be ready after installation.
+
+### Using Makefile
+
+Prerrequisites:
+
 - A running Kubernetes cluster (v1.24+)
 - kubectl (v1.24+)
 - Make

--- a/api/v1/redkeycluster_types.go
+++ b/api/v1/redkeycluster_types.go
@@ -85,35 +85,31 @@ const (
 )
 
 var ConditionUpgrading = metav1.Condition{
-	Type:               "Upgrading",
-	LastTransitionTime: metav1.Now(),
-	Message:            "Redkey cluster is upgrading",
-	Reason:             "RedkeyClusterUpgrading",
-	Status:             metav1.ConditionTrue,
+	Type:    "Upgrading",
+	Message: "Redkey cluster is upgrading",
+	Reason:  "RedkeyClusterUpgrading",
+	Status:  metav1.ConditionTrue,
 }
 
 var ConditionScalingUp = metav1.Condition{
-	Type:               "ScalingUp",
-	LastTransitionTime: metav1.Now(),
-	Message:            "Redkey cluster is scaling up",
-	Reason:             "RedkeyClusterScalingUp",
-	Status:             metav1.ConditionTrue,
+	Type:    "ScalingUp",
+	Message: "Redkey cluster is scaling up",
+	Reason:  "RedkeyClusterScalingUp",
+	Status:  metav1.ConditionTrue,
 }
 
 var ConditionScalingDown = metav1.Condition{
-	Type:               "ScalingDown",
-	LastTransitionTime: metav1.Now(),
-	Message:            "Redkey cluster is scaling down",
-	Reason:             "RedkeyClusterScalingDown",
-	Status:             metav1.ConditionTrue,
+	Type:    "ScalingDown",
+	Message: "Redkey cluster is scaling down",
+	Reason:  "RedkeyClusterScalingDown",
+	Status:  metav1.ConditionTrue,
 }
 
 var ConditionReady = metav1.Condition{
-	Type:               "Ready",
-	LastTransitionTime: metav1.Now(),
-	Message:            "Redkey cluster is ready",
-	Reason:             "RedkeyClusterReady",
-	Status:             metav1.ConditionTrue,
+	Type:    "Ready",
+	Message: "Redkey cluster is ready",
+	Reason:  "RedkeyClusterReady",
+	Status:  metav1.ConditionTrue,
 }
 
 var AllConditions = []metav1.Condition{ConditionUpgrading, ConditionScalingUp, ConditionScalingDown, ConditionReady}

--- a/api/v1/redkeycluster_types.go
+++ b/api/v1/redkeycluster_types.go
@@ -99,6 +99,7 @@ var ConditionScalingUp = metav1.Condition{
 	Reason:             "RedkeyClusterScalingUp",
 	Status:             metav1.ConditionTrue,
 }
+
 var ConditionScalingDown = metav1.Condition{
 	Type:               "ScalingDown",
 	LastTransitionTime: metav1.Now(),
@@ -107,7 +108,15 @@ var ConditionScalingDown = metav1.Condition{
 	Status:             metav1.ConditionTrue,
 }
 
-var AllConditions = []metav1.Condition{ConditionUpgrading, ConditionScalingUp, ConditionScalingDown}
+var ConditionReady = metav1.Condition{
+	Type:               "Ready",
+	LastTransitionTime: metav1.Now(),
+	Message:            "Redkey cluster is ready",
+	Reason:             "RedkeyClusterReady",
+	Status:             metav1.ConditionTrue,
+}
+
+var AllConditions = []metav1.Condition{ConditionUpgrading, ConditionScalingUp, ConditionScalingDown, ConditionReady}
 
 // +kubebuilder:object:root=true
 // RedkeyClusterList contains a list of RedkeyCluster

--- a/api/v1/redkeycluster_types.go
+++ b/api/v1/redkeycluster_types.go
@@ -5,6 +5,8 @@
 package v1
 
 import (
+	"reflect"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -610,6 +612,12 @@ func CompareStatuses(a, b *RedkeyClusterStatus) bool {
 		return false
 	}
 	if a.Substatus.Status != b.Substatus.Status {
+		return false
+	}
+	// Check the conditions array, to detect changes in the cluster status that are not reflected in
+	// the main status or substatus fields, like PDB enabling/disabiling. We need to identify
+	// ObservedGeneration changes that don't trigger a status or substatus change but do trigger a conditions change.
+	if !reflect.DeepEqual(a.Conditions, b.Conditions) {
 		return false
 	}
 	for _, nodeA := range a.Nodes {

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,25 @@
+# Helm Charts
+
+This directory contains Helm charts for deploying the various components of the project. Each subdirectory corresponds to a specific component and includes the necessary templates and configuration files for deployment.
+
+## redkey-cluster Chart
+
+Use this chart to deploy a Redkey cluster.
+
+You can create a Readkey cluster by executindg the following command:
+
+```bash
+helm install my-redkey-cluster ./charts/redkey-cluster
+```
+
+This chart includes a **Helm post-install hook** that checks if the cluster is healthy after installation, waiting for `Condition "Ready"` to be true in the RedkeyCluster Custom Resource.
+
+To use the chart with the post-install hook enabled, override the `waitReady.enabled` value to `true` in your `values.yaml` or via the command line:
+
+```bash
+# If you want to rollback on failure.
+helm install my-redkey-cluster ./charts/redkey-cluster --set waitReady.enabled=true --rollback-on-failure
+
+# If you want to skip rollback on failure.
+helm install my-redkey-cluster ./charts/redkey-cluster --set waitReady.enabled=true
+```

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,6 +1,22 @@
+<!--
+SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # Helm Charts
 
 This directory contains Helm charts for deploying the various components of the project. Each subdirectory corresponds to a specific component and includes the necessary templates and configuration files for deployment.
+
+## redkey-operator Chart
+
+Use this chart to deploy the Redkey Operator, which manages Redkey clusters in your Kubernetes environment.
+
+You can install the Redkey Operator by running the following command:
+
+```bash
+helm install my-redkey-operator ./charts/redkey-operator
+```
 
 ## redkey-cluster Chart
 

--- a/charts/redkey-cluster/Chart.yaml
+++ b/charts/redkey-cluster/Chart.yaml
@@ -6,4 +6,4 @@ name: redkey-cluster
 description: A Helm chart for deploying a RedkeyCluster custom resource
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: "0.1.0"

--- a/charts/redkey-cluster/Chart.yaml
+++ b/charts/redkey-cluster/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: redkey-cluster
+description: A Helm chart for deploying a RedkeyCluster custom resource
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/redkey-cluster/Chart.yaml
+++ b/charts/redkey-cluster/Chart.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v2
 name: redkey-cluster
 description: A Helm chart for deploying a RedkeyCluster custom resource

--- a/charts/redkey-cluster/templates/_helpers.tpl
+++ b/charts/redkey-cluster/templates/_helpers.tpl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 {{- define "redkey-cluster.name" -}}
 {{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/redkey-cluster/templates/_helpers.tpl
+++ b/charts/redkey-cluster/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{- define "redkey-cluster.name" -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "redkey-cluster.labels" -}}
+app.kubernetes.io/name: redkey-cluster-operator
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}

--- a/charts/redkey-cluster/templates/redkeycluster.yaml
+++ b/charts/redkey-cluster/templates/redkeycluster.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: redkey.inditex.dev/v1
 kind: RedkeyCluster
 metadata:

--- a/charts/redkey-cluster/templates/redkeycluster.yaml
+++ b/charts/redkey-cluster/templates/redkeycluster.yaml
@@ -1,0 +1,65 @@
+apiVersion: redkey.inditex.dev/v1
+kind: RedkeyCluster
+metadata:
+  name: {{ include "redkey-cluster.name" . }}
+  labels:
+    {{- include "redkey-cluster.labels" . | nindent 4 }}
+spec:
+  primaries: {{ .Values.primaries }}
+  replicasPerPrimary: {{ .Values.replicasPerPrimary }}
+  ephemeral: {{ .Values.ephemeral }}
+  {{- if .Values.purgeKeysOnRebalance }}
+  purgeKeysOnRebalance: {{ .Values.purgeKeysOnRebalance }}
+  {{- end }}
+  image: {{ .Values.image }}
+  {{- if and (not .Values.ephemeral) .Values.storage }}
+  storage: {{ .Values.storage }}
+  {{- end }}
+  {{- if and (not .Values.ephemeral) .Values.storageClassName }}
+  storageClassName: {{ .Values.storageClassName }}
+  {{- end }}
+  accessModes:
+    {{- toYaml .Values.accessModes | nindent 4 }}
+  {{- if .Values.deletePVC }}
+  deletePVC: {{ .Values.deletePVC }}
+  {{- end }}
+  {{- if .Values.backup }}
+  backup: {{ .Values.backup }}
+  {{- end }}
+  {{- if .Values.labels }}
+  labels:
+    {{- toYaml .Values.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.config }}
+  config: |
+    {{- .Values.config | nindent 4 }}
+  {{- end }}
+  {{- if .Values.resources }}
+  resources:
+    {{- toYaml .Values.resources | nindent 4 }}
+  {{- end }}
+  robin:
+    config:
+      {{- toYaml .Values.robin.config | nindent 6 }}
+    template:
+      spec:
+        containers:
+          - image: {{ .Values.robin.image }}
+            name: robin
+            imagePullPolicy: {{ .Values.robin.imagePullPolicy }}
+            ports:
+              - containerPort: 8080
+                name: prometheus
+                protocol: TCP
+            volumeMounts:
+              - mountPath: /opt/conf/configmap
+                name: {{ include "redkey-cluster.name" . }}-robin-config
+            {{- if .Values.robin.resources }}
+            resources:
+              {{- toYaml .Values.robin.resources | nindent 14 }}
+            {{- end }}
+        volumes:
+          - configMap:
+              defaultMode: 420
+              name: {{ include "redkey-cluster.name" . }}-robin
+            name: {{ include "redkey-cluster.name" . }}-robin-config

--- a/charts/redkey-cluster/templates/wait-ready-hook.yaml
+++ b/charts/redkey-cluster/templates/wait-ready-hook.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.waitReady.enabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/redkey-cluster/templates/wait-ready-hook.yaml
+++ b/charts/redkey-cluster/templates/wait-ready-hook.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.waitReady.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redkey-cluster.name" . }}-wait-ready
+  labels:
+    {{- include "redkey-cluster.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "redkey-cluster.name" . }}-wait-ready
+  labels:
+    {{- include "redkey-cluster.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: ["redkey.inditex.dev"]
+    resources: ["redkeyclusters"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "redkey-cluster.name" . }}-wait-ready
+  labels:
+    {{- include "redkey-cluster.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "redkey-cluster.name" . }}-wait-ready
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "redkey-cluster.name" . }}-wait-ready
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "redkey-cluster.name" . }}-wait-ready
+  labels:
+    {{- include "redkey-cluster.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "redkey-cluster.name" . }}-wait-ready
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "redkey-cluster.name" . }}-wait-ready
+      containers:
+        - name: wait
+          image: {{ .Values.waitReady.image }}
+          command:
+            - kubectl
+            - wait
+            - --for=condition=Ready
+            - redkeycluster/{{ include "redkey-cluster.name" . }}
+            - -n
+            - {{ .Release.Namespace }}
+            - --timeout={{ .Values.waitReady.timeout }}
+  backoffLimit: {{ .Values.waitReady.backoffLimit }}
+{{- end }}

--- a/charts/redkey-cluster/values.yaml
+++ b/charts/redkey-cluster/values.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
 # RedkeyCluster name (defaults to release name)
 nameOverride: ""
 

--- a/charts/redkey-cluster/values.yaml
+++ b/charts/redkey-cluster/values.yaml
@@ -1,0 +1,83 @@
+# RedkeyCluster name (defaults to release name)
+nameOverride: ""
+
+primaries: 3
+replicasPerPrimary: 0
+ephemeral: true
+purgeKeysOnRebalance: true
+image: redis:8-bookworm
+
+# Storage (only for non-ephemeral clusters)
+storage: ""
+storageClassName: ""
+accessModes:
+  - ReadWriteOnce
+
+# deletePVC: false
+# backup: false
+
+labels:
+  team: a-team
+  custom: custom-label
+
+config: |
+  maxmemory 90mb
+  maxmemory-samples 5
+  maxmemory-policy allkeys-lru
+  protected-mode no
+  appendonly no
+  save ""
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+robin:
+  image: ghcr.io/inditextech/redkey-robin:0.1.0
+  imagePullPolicy: Always
+  resources:
+    requests:
+      cpu: 500m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 200Mi
+  config:
+    reconciler:
+      intervalSeconds: 30
+      operationCleanUpIntervalSeconds: 30
+    cluster:
+      healthProbePeriodSeconds: 60
+      healingTimeSeconds: 60
+      maxRetries: 10
+      backOff: 10
+    metrics:
+      intervalSeconds: 60
+      redisInfoKeys:
+        - keyspace_hits
+        - evicted_keys
+        - connected_clients
+        - total_commands_processed
+        - keyspace_misses
+        - expired_keys
+        - redis_version
+        - used_memory_rss
+        - maxmemory
+        - used_cpu_sys
+        - used_cpu_sys_children
+        - used_cpu_user
+        - used_cpu_user_children
+        - total_net_input_bytes
+        - total_net_output_bytes
+        - aof_base_size
+        - aof_current_size
+        - mem_aof_buffer
+
+# Post-install hook that waits for the RedkeyCluster to be Ready.
+# All RBAC resources are auto-created and auto-cleaned by Helm hooks.
+waitReady:
+  enabled: false
+  image: bitnami/kubectl:latest
+  timeout: "300s"
+  backoffLimit: 3

--- a/charts/redkey-operator/Chart.yaml
+++ b/charts/redkey-operator/Chart.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: redkey-operator
+description: A Helm chart for deploying the Redkey Operator
+
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/redkey-operator/crds/crd.yaml
+++ b/charts/redkey-operator/crds/crd.yaml
@@ -1,0 +1,7775 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    inditex.dev/operator-version: 0.1.0
+  name: redkeyclusters.redkey.inditex.dev
+spec:
+  group: redkey.inditex.dev
+  names:
+    kind: RedkeyCluster
+    listKind: RedkeyClusterList
+    plural: redkeyclusters
+    shortNames:
+    - rkcl
+    singular: redkeycluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Amount of Redis primary nodes
+      jsonPath: .spec.primaries
+      name: Primaries
+      type: integer
+    - description: Amount of replicas per primary node
+      jsonPath: .spec.replicasPerPrimary
+      name: Replicas
+      type: integer
+    - description: Cluster ephemeral
+      jsonPath: .spec.ephemeral
+      name: Ephemeral
+      type: boolean
+    - description: Purge keys on rebalance
+      jsonPath: .spec.purgeKeysOnRebalance
+      name: PurgeKeys
+      type: boolean
+    - description: Source image for Redis instance
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: Amount of storage for Redis
+      jsonPath: .spec.storage
+      name: Storage
+      type: string
+    - description: Storage Class to be used by the PVC
+      jsonPath: .spec.storageClassName
+      name: StorageClassName
+      priority: 10
+      type: string
+    - description: Deleve PVC
+      jsonPath: .spec.deletePVC
+      name: DeletePVC
+      priority: 5
+      type: boolean
+    - description: The cluster status
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - description: The cluster substatus
+      jsonPath: .status.substatus.status
+      name: Substatus
+      type: string
+    - description: Upgrading partition
+      jsonPath: .status.substatus.upgradingPartition
+      name: Partition
+      priority: 5
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              accessModes:
+                default:
+                - ReadWriteOnce
+                items:
+                  enum:
+                  - ReadWriteOnce
+                  - ReadOnlyMany
+                  - ReadWriteMany
+                  type: string
+                type: array
+                x-kubernetes-validations:
+                - message: Changing the storage access modes is not allowed
+                  rule: self == oldSelf
+              auth:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              backup:
+                type: boolean
+              config:
+                type: string
+              deletePVC:
+                default: false
+                type: boolean
+              ephemeral:
+                default: true
+                type: boolean
+                x-kubernetes-validations:
+                - message: Changing the ephemeral field is not allowed
+                  rule: self == oldSelf
+              image:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              override:
+                properties:
+                  service:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      metadata:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            type: boolean
+                          clusterIP:
+                            type: string
+                          clusterIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          ipFamilies:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-preserve-unknown-fields: true
+                          ipFamilyPolicy:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  statefulSet:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      metadata:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        properties:
+                          minReadySeconds:
+                            format: int32
+                            type: integer
+                          ordinals:
+                            properties:
+                              start:
+                                format: int32
+                                type: integer
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          persistentVolumeClaimRetentionPolicy:
+                            properties:
+                              whenDeleted:
+                                type: string
+                              whenScaled:
+                                type: string
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          podManagementPolicy:
+                            type: string
+                          replicas:
+                            format: int32
+                            type: integer
+                          revisionHistoryLimit:
+                            format: int32
+                            type: integer
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          serviceName:
+                            type: string
+                          template:
+                            properties:
+                              metadata:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              spec:
+                                properties:
+                                  activeDeadlineSeconds:
+                                    format: int64
+                                    type: integer
+                                  affinity:
+                                    properties:
+                                      nodeAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                preference:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            properties:
+                                              nodeSelectorTerms:
+                                                items:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      podAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    matchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    mismatchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    matchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    mismatchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
+                                  automountServiceAccountToken:
+                                    type: boolean
+                                  containers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  dnsConfig:
+                                    properties:
+                                      nameservers:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      options:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      searches:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  dnsPolicy:
+                                    type: string
+                                  enableServiceLinks:
+                                    type: boolean
+                                  ephemeralContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        targetContainerName:
+                                          type: string
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  hostAliases:
+                                    items:
+                                      properties:
+                                        hostnames:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        ip:
+                                          type: string
+                                      required:
+                                      - ip
+                                      type: object
+                                    type: array
+                                  hostIPC:
+                                    type: boolean
+                                  hostNetwork:
+                                    type: boolean
+                                  hostPID:
+                                    type: boolean
+                                  hostname:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                  initContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeName:
+                                    type: string
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  overhead:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  preemptionPolicy:
+                                    type: string
+                                  priority:
+                                    format: int32
+                                    type: integer
+                                  priorityClassName:
+                                    type: string
+                                  readinessGates:
+                                    items:
+                                      properties:
+                                        conditionType:
+                                          type: string
+                                      required:
+                                      - conditionType
+                                      type: object
+                                    type: array
+                                  restartPolicy:
+                                    type: string
+                                  runtimeClassName:
+                                    type: string
+                                  schedulerName:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      fsGroup:
+                                        format: int64
+                                        type: integer
+                                      fsGroupChangePolicy:
+                                        type: string
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxChangePolicy:
+                                        type: string
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      supplementalGroups:
+                                        items:
+                                          format: int64
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      supplementalGroupsPolicy:
+                                        type: string
+                                      sysctls:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  securityGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  serviceAccount:
+                                    type: string
+                                  serviceAccountName:
+                                    type: string
+                                  shareProcessNamespace:
+                                    type: boolean
+                                  subdomain:
+                                    type: string
+                                  terminationGracePeriodSeconds:
+                                    format: int64
+                                    type: integer
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  topologySpreadConstraints:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        maxSkew:
+                                          format: int32
+                                          type: integer
+                                        minDomains:
+                                          format: int32
+                                          type: integer
+                                        nodeAffinityPolicy:
+                                          type: string
+                                        nodeTaintsPolicy:
+                                          type: string
+                                        topologyKey:
+                                          type: string
+                                        whenUnsatisfiable:
+                                          type: string
+                                      required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      type: object
+                                    type: array
+                                  volumes:
+                                    items:
+                                      properties:
+                                        awsElasticBlockStore:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        azureDisk:
+                                          properties:
+                                            cachingMode:
+                                              type: string
+                                            diskName:
+                                              type: string
+                                            diskURI:
+                                              type: string
+                                            fsType:
+                                              default: ext4
+                                              type: string
+                                            kind:
+                                              type: string
+                                            readOnly:
+                                              default: false
+                                              type: boolean
+                                          required:
+                                          - diskName
+                                          - diskURI
+                                          type: object
+                                        azureFile:
+                                          properties:
+                                            readOnly:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                            shareName:
+                                              type: string
+                                          required:
+                                          - secretName
+                                          - shareName
+                                          type: object
+                                        cephfs:
+                                          properties:
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretFile:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              type: string
+                                          required:
+                                          - monitors
+                                          type: object
+                                        cinder:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        configMap:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        csi:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            nodePublishSecretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            readOnly:
+                                              type: boolean
+                                            volumeAttributes:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          required:
+                                          - driver
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        emptyDir:
+                                          properties:
+                                            medium:
+                                              type: string
+                                            sizeLimit:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        ephemeral:
+                                          properties:
+                                            volumeClaimTemplate:
+                                              properties:
+                                                metadata:
+                                                  type: object
+                                                spec:
+                                                  properties:
+                                                    accessModes:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    dataSource:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    dataSourceRef:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        namespace:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                    resources:
+                                                      properties:
+                                                        limits:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                        requests:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                      type: object
+                                                    selector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    storageClassName:
+                                                      type: string
+                                                    volumeAttributesClassName:
+                                                      type: string
+                                                    volumeMode:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - spec
+                                              type: object
+                                          type: object
+                                        fc:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            targetWWNs:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            wwids:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        flexVolume:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            options:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - driver
+                                          type: object
+                                        flocker:
+                                          properties:
+                                            datasetName:
+                                              type: string
+                                            datasetUUID:
+                                              type: string
+                                          type: object
+                                        gcePersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            pdName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - pdName
+                                          type: object
+                                        gitRepo:
+                                          properties:
+                                            directory:
+                                              type: string
+                                            repository:
+                                              type: string
+                                            revision:
+                                              type: string
+                                          required:
+                                          - repository
+                                          type: object
+                                        glusterfs:
+                                          properties:
+                                            endpoints:
+                                              type: string
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - endpoints
+                                          - path
+                                          type: object
+                                        hostPath:
+                                          properties:
+                                            path:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                        image:
+                                          properties:
+                                            pullPolicy:
+                                              type: string
+                                            reference:
+                                              type: string
+                                          type: object
+                                        iscsi:
+                                          properties:
+                                            chapAuthDiscovery:
+                                              type: boolean
+                                            chapAuthSession:
+                                              type: boolean
+                                            fsType:
+                                              type: string
+                                            initiatorName:
+                                              type: string
+                                            iqn:
+                                              type: string
+                                            iscsiInterface:
+                                              default: default
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            portals:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            targetPortal:
+                                              type: string
+                                          required:
+                                          - iqn
+                                          - lun
+                                          - targetPortal
+                                          type: object
+                                        name:
+                                          type: string
+                                        nfs:
+                                          properties:
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            server:
+                                              type: string
+                                          required:
+                                          - path
+                                          - server
+                                          type: object
+                                        persistentVolumeClaim:
+                                          properties:
+                                            claimName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - claimName
+                                          type: object
+                                        photonPersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            pdID:
+                                              type: string
+                                          required:
+                                          - pdID
+                                          type: object
+                                        portworxVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        projected:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            sources:
+                                              items:
+                                                properties:
+                                                  clusterTrustBundle:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      signerName:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  configMap:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  downwardAPI:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            fieldRef:
+                                                              properties:
+                                                                apiVersion:
+                                                                  type: string
+                                                                fieldPath:
+                                                                  type: string
+                                                              required:
+                                                              - fieldPath
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                            resourceFieldRef:
+                                                              properties:
+                                                                containerName:
+                                                                  type: string
+                                                                divisor:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                resource:
+                                                                  type: string
+                                                              required:
+                                                              - resource
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  secret:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  serviceAccountToken:
+                                                    properties:
+                                                      audience:
+                                                        type: string
+                                                      expirationSeconds:
+                                                        format: int64
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        quobyte:
+                                          properties:
+                                            group:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            registry:
+                                              type: string
+                                            tenant:
+                                              type: string
+                                            user:
+                                              type: string
+                                            volume:
+                                              type: string
+                                          required:
+                                          - registry
+                                          - volume
+                                          type: object
+                                        rbd:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            image:
+                                              type: string
+                                            keyring:
+                                              default: /etc/ceph/keyring
+                                              type: string
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            pool:
+                                              default: rbd
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              default: admin
+                                              type: string
+                                          required:
+                                          - image
+                                          - monitors
+                                          type: object
+                                        scaleIO:
+                                          properties:
+                                            fsType:
+                                              default: xfs
+                                              type: string
+                                            gateway:
+                                              type: string
+                                            protectionDomain:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            sslEnabled:
+                                              type: boolean
+                                            storageMode:
+                                              default: ThinProvisioned
+                                              type: string
+                                            storagePool:
+                                              type: string
+                                            system:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                          - gateway
+                                          - secretRef
+                                          - system
+                                          type: object
+                                        secret:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            optional:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                          type: object
+                                        storageos:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeName:
+                                              type: string
+                                            volumeNamespace:
+                                              type: string
+                                          type: object
+                                        vsphereVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            storagePolicyID:
+                                              type: string
+                                            storagePolicyName:
+                                              type: string
+                                            volumePath:
+                                              type: string
+                                          required:
+                                          - volumePath
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          updateStrategy:
+                            properties:
+                              rollingUpdate:
+                                properties:
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                kind:
+                                  type: string
+                                metadata:
+                                  type: object
+                                spec:
+                                  properties:
+                                    accessModes:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      properties:
+                                        apiGroup:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      properties:
+                                        apiGroup:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      type: string
+                                    volumeAttributesClassName:
+                                      type: string
+                                    volumeMode:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  type: object
+                                status:
+                                  properties:
+                                    accessModes:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    allocatedResourceStatuses:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                      x-kubernetes-map-type: granular
+                                    allocatedResources:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    capacity:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    conditions:
+                                      items:
+                                        properties:
+                                          lastProbeTime:
+                                            format: date-time
+                                            type: string
+                                          lastTransitionTime:
+                                            format: date-time
+                                            type: string
+                                          message:
+                                            type: string
+                                          reason:
+                                            type: string
+                                          status:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - status
+                                        - type
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - type
+                                      x-kubernetes-list-type: map
+                                    currentVolumeAttributesClassName:
+                                      type: string
+                                    modifyVolumeStatus:
+                                      properties:
+                                        status:
+                                          type: string
+                                        targetVolumeAttributesClassName:
+                                          type: string
+                                      required:
+                                      - status
+                                      type: object
+                                    phase:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              pdb:
+                properties:
+                  enabled:
+                    type: boolean
+                  pdbSizeAvailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                  pdbSizeUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                type: object
+              primaries:
+                format: int32
+                type: integer
+              purgeKeysOnRebalance:
+                default: true
+                type: boolean
+              replicasPerPrimary:
+                default: 0
+                format: int32
+                type: integer
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        request:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              robin:
+                properties:
+                  config:
+                    properties:
+                      cluster:
+                        properties:
+                          backOff:
+                            type: integer
+                          healingTimeSeconds:
+                            type: integer
+                          healthProbePeriodSeconds:
+                            type: integer
+                          maxRetries:
+                            type: integer
+                        type: object
+                      metrics:
+                        properties:
+                          intervalSeconds:
+                            type: integer
+                          redisInfoKeys:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      reconciler:
+                        properties:
+                          intervalSeconds:
+                            type: integer
+                          operationCleanUpIntervalSeconds:
+                            type: integer
+                        type: object
+                    type: object
+                  template:
+                    properties:
+                      metadata:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            format: int64
+                            type: integer
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - preference
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - nodeSelectorTerms
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            type: boolean
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              searches:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          dnsPolicy:
+                            type: string
+                          enableServiceLinks:
+                            type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          fsGroup:
+                            format: int64
+                            type: integer
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                ip:
+                                  type: string
+                              required:
+                              - ip
+                              type: object
+                            type: array
+                          hostIPC:
+                            type: boolean
+                          hostNetwork:
+                            type: boolean
+                          hostPID:
+                            type: boolean
+                          hostname:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          nodeName:
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          preemptionPolicy:
+                            type: string
+                          priority:
+                            format: int32
+                            type: integer
+                          priorityClassName:
+                            type: string
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: string
+                              required:
+                              - conditionType
+                              type: object
+                            type: array
+                          restartPolicy:
+                            type: string
+                          runtimeClassName:
+                            type: string
+                          schedulerName:
+                            type: string
+                          securityContext:
+                            properties:
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              fsGroup:
+                                format: int64
+                                type: integer
+                              fsGroupChangePolicy:
+                                type: string
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxChangePolicy:
+                                type: string
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              supplementalGroups:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              supplementalGroupsPolicy:
+                                type: string
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          securityGroups:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          serviceAccount:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          shareProcessNamespace:
+                            type: boolean
+                          subdomain:
+                            type: string
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                maxSkew:
+                                  format: int32
+                                  type: integer
+                                minDomains:
+                                  format: int32
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                              type: object
+                            type: array
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: string
+                                    diskName:
+                                      type: string
+                                    diskURI:
+                                      type: string
+                                    fsType:
+                                      default: ext4
+                                      type: string
+                                    kind:
+                                      type: string
+                                    readOnly:
+                                      default: false
+                                      type: boolean
+                                  required:
+                                  - diskName
+                                  - diskURI
+                                  type: object
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                    shareName:
+                                      type: string
+                                  required:
+                                  - secretName
+                                  - shareName
+                                  type: object
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretFile:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      type: string
+                                  required:
+                                  - monitors
+                                  type: object
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  properties:
+                                    volumeClaimTemplate:
+                                      properties:
+                                        metadata:
+                                          type: object
+                                        spec:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            storageClassName:
+                                              type: string
+                                            volumeAttributesClassName:
+                                              type: string
+                                            volumeMode:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          type: object
+                                      required:
+                                      - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    targetWWNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    wwids:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - driver
+                                  type: object
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: string
+                                    datasetUUID:
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - pdName
+                                  type: object
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: string
+                                    repository:
+                                      type: string
+                                    revision:
+                                      type: string
+                                  required:
+                                  - repository
+                                  type: object
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: string
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - endpoints
+                                  - path
+                                  type: object
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: boolean
+                                    chapAuthSession:
+                                      type: boolean
+                                    fsType:
+                                      type: string
+                                    initiatorName:
+                                      type: string
+                                    iqn:
+                                      type: string
+                                    iscsiInterface:
+                                      default: default
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetPortal:
+                                      type: string
+                                  required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                  type: object
+                                name:
+                                  type: string
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    server:
+                                      type: string
+                                  required:
+                                  - path
+                                  - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    pdID:
+                                      type: string
+                                  required:
+                                  - pdID
+                                  type: object
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      items:
+                                        properties:
+                                          clusterTrustBundle:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              signerName:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          downwardAPI:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          secret:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    registry:
+                                      type: string
+                                    tenant:
+                                      type: string
+                                    user:
+                                      type: string
+                                    volume:
+                                      type: string
+                                  required:
+                                  - registry
+                                  - volume
+                                  type: object
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    image:
+                                      type: string
+                                    keyring:
+                                      default: /etc/ceph/keyring
+                                      type: string
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    pool:
+                                      default: rbd
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      default: admin
+                                      type: string
+                                  required:
+                                  - image
+                                  - monitors
+                                  type: object
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      default: xfs
+                                      type: string
+                                    gateway:
+                                      type: string
+                                    protectionDomain:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sslEnabled:
+                                      type: boolean
+                                    storageMode:
+                                      default: ThinProvisioned
+                                      type: string
+                                    storagePool:
+                                      type: string
+                                    system:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeName:
+                                      type: string
+                                    volumeNamespace:
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    storagePolicyID:
+                                      type: string
+                                    storagePolicyName:
+                                      type: string
+                                    volumePath:
+                                      type: string
+                                  required:
+                                  - volumePath
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          windowsOptions:
+                            properties:
+                              gmsaCredentialSpec:
+                                type: string
+                              gmsaCredentialSpecName:
+                                type: string
+                              hostProcess:
+                                type: boolean
+                              runAsUserName:
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              storage:
+                type: string
+                x-kubernetes-validations:
+                - message: Changing the storage size is not allowed
+                  rule: self == oldSelf
+              storageClassName:
+                default: ""
+                type: string
+                x-kubernetes-validations:
+                - message: Changing the storage class name is not allowed
+                  rule: self == oldSelf
+              version:
+                type: string
+            required:
+            - primaries
+            type: object
+            x-kubernetes-validations:
+            - message: Ephemeral or storage must be set
+              rule: self.ephemeral || has(self.storage)
+            - message: Ephemeral and storage cannot be combined
+              rule: '!(self.ephemeral && has(self.storage))'
+            - message: Cannot set purgeKeysOnRebalance to true for non-ephemeral clusters
+              rule: '!(!self.ephemeral && self.purgeKeysOnRebalance == true)'
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              nodes:
+                additionalProperties:
+                  properties:
+                    ip:
+                      type: string
+                    isPrimary:
+                      type: boolean
+                    name:
+                      type: string
+                    replicaOf:
+                      type: string
+                  required:
+                  - ip
+                  - isPrimary
+                  - name
+                  - replicaOf
+                  type: object
+                type: object
+              status:
+                type: string
+              substatus:
+                properties:
+                  status:
+                    type: string
+                  upgradingPartition:
+                    type: string
+                type: object
+            required:
+            - nodes
+            - status
+            - substatus
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: Changing the number of primaries is not allowed unless the cluster
+            is in 'Ready' status
+          rule: self.spec.primaries == oldSelf.spec.primaries || !has(self.status)
+            || self.status.status == 'Ready'
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.primaries
+        statusReplicasPath: .status.primaries
+      status: {}

--- a/charts/redkey-operator/templates/_helpers.tpl
+++ b/charts/redkey-operator/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redkey-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redkey-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redkey-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redkey-operator.labels" -}}
+helm.sh/chart: {{ include "redkey-operator.chart" . }}
+{{ include "redkey-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redkey-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redkey-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redkey-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "redkey-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/redkey-operator/templates/configmap.yaml
+++ b/charts/redkey-operator/templates/configmap.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+data:
+  redkey_operator_config.yaml: |
+    # SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+    # SPDX-License-Identifier: Apache-2.0
+
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081

--- a/charts/redkey-operator/templates/deployment.yaml
+++ b/charts/redkey-operator/templates/deployment.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "redkey-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "redkey-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "redkey-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command:
+            - /manager
+          args:
+            - "--leader-elect={{ .Values.leaderElection.enabled }}"
+            - "--max-concurrent-reconciles"
+            - "10"
+          env:
+            - name: WATCH_NAMESPACE
+              value: {{ .Release.Namespace }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/redkey-operator/templates/rbac.yaml
+++ b/charts/redkey-operator/templates/rbac.yaml
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "redkey-operator.fullname" . }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "redkey-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-manager
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - update
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - deletecollection
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-manager
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redkey-operator.fullname" . }}-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "redkey-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-editor
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redkey-operator.fullname" . }}-viewer
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - redkey.inditex.dev
+  resources:
+  - redkeyclusters/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/redkey-operator/templates/serviceaccount.yaml
+++ b/charts/redkey-operator/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redkey-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redkey-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/redkey-operator/values.yaml
+++ b/charts/redkey-operator/values.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 INDUSTRIA DE DISEÑO TEXTIL S.A. (INDITEX S.A.)
+# SPDX-License-Identifier: Apache-2.0
+
+# Default values for redkey-operator.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/inditextech/redkey-operator
+  pullPolicy: IfNotPresent
+  tag: "0.1.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "redkey-operator-sa"
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+leaderElection:
+  enabled: true
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+
+securityContext:
+  allowPrivilegeEscalation: false
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -12,16 +12,19 @@ import (
 )
 
 func (r *RedkeyClusterReconciler) setConditionTrue(rc *redkeyv1.RedkeyCluster, condition metav1.Condition, message string) {
-	if !meta.IsStatusConditionTrue(rc.Status.Conditions, condition.Type) {
-		meta.SetStatusCondition(&rc.Status.Conditions, condition)
-		r.Recorder.Event(rc, "Normal", condition.Reason, message)
-	}
+	condition.ObservedGeneration = rc.Generation
+	condition.Message = message
+	alreadyTrue := meta.IsStatusConditionTrue(rc.Status.Conditions, condition.Type)
+	if meta.SetStatusCondition(&rc.Status.Conditions, condition) && !alreadyTrue {
+        r.Recorder.Event(rc, "Normal", condition.Reason, message)		// Event generated only when condition changes to true
+    }
 }
 
 func setConditionFalse(log logr.Logger, redkeyCluster *redkeyv1.RedkeyCluster, condition metav1.Condition) {
 	condition.Status = metav1.ConditionFalse
-	changed := meta.SetStatusCondition(&redkeyCluster.Status.Conditions, condition)
-	if changed {
+	condition.ObservedGeneration = redkeyCluster.Generation
+
+	if meta.SetStatusCondition(&redkeyCluster.Status.Conditions, condition) {
 		log.Info("Condition set to false", "condition", condition)
 	}
 }

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -16,8 +16,8 @@ func (r *RedkeyClusterReconciler) setConditionTrue(rc *redkeyv1.RedkeyCluster, c
 	condition.Message = message
 	alreadyTrue := meta.IsStatusConditionTrue(rc.Status.Conditions, condition.Type)
 	if meta.SetStatusCondition(&rc.Status.Conditions, condition) && !alreadyTrue {
-        r.Recorder.Event(rc, "Normal", condition.Reason, message)		// Event generated only when condition changes to true
-    }
+		r.Recorder.Event(rc, "Normal", condition.Reason, message) // Event generated only when condition changes to true
+	}
 }
 
 func setConditionFalse(log logr.Logger, redkeyCluster *redkeyv1.RedkeyCluster, condition metav1.Condition) {

--- a/controllers/redis_manager.go
+++ b/controllers/redis_manager.go
@@ -797,7 +797,13 @@ func (r *RedkeyClusterReconciler) doFastScaling(ctx context.Context, redkeyClust
 			return true, nil
 		}
 
-		// The cluster is now scaled, and we can set the Cluster Status as Ready again and remove the Substatus.
+		// The cluster is now scaled, and we can set the Cluster Status to Ready again, remove the Substatus and update conditions accordingly.
+		switch redkeyCluster.Status.Status {
+		case redkeyv1.StatusScalingUp:
+			setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingUp)
+		case redkeyv1.StatusScalingDown:
+			setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingDown)
+		}
 		redkeyCluster.Status.Status = redkeyv1.StatusReady
 		redkeyCluster.Status.Substatus.Status = ""
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")

--- a/controllers/redis_manager.go
+++ b/controllers/redis_manager.go
@@ -68,6 +68,7 @@ func (r *RedkeyClusterReconciler) clusterScaledToZeroPrimaries(ctx context.Conte
 	if !reflect.DeepEqual(redkeyCluster.Status, redkeyv1.StatusReady) {
 		redkeyCluster.Status.Status = redkeyv1.StatusReady
 		setAllConditionsFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster)
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 		update_err = r.updateClusterStatus(ctx, redkeyCluster)
 	}
 
@@ -161,6 +162,7 @@ func (r *RedkeyClusterReconciler) doFastUpgrade(ctx context.Context, redkeyClust
 		redkeyCluster.Status.Status = redkeyv1.StatusReady
 		redkeyCluster.Status.Substatus.Status = ""
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionUpgrading)
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 
 		return true, nil
 	default:
@@ -600,6 +602,7 @@ func (r *RedkeyClusterReconciler) doSlowUpgradeScalingDown(ctx context.Context, 
 	redkeyCluster.Status.Substatus.Status = ""
 	redkeyCluster.Status.Substatus.UpgradingPartition = ""
 	setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionUpgrading)
+	r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 
 	return nil
 }
@@ -797,6 +800,7 @@ func (r *RedkeyClusterReconciler) doFastScaling(ctx context.Context, redkeyClust
 		// The cluster is now scaled, and we can set the Cluster Status as Ready again and remove the Substatus.
 		redkeyCluster.Status.Status = redkeyv1.StatusReady
 		redkeyCluster.Status.Substatus.Status = ""
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 
 		return true, nil
 	default:

--- a/controllers/redis_manager_test.go
+++ b/controllers/redis_manager_test.go
@@ -34,6 +34,7 @@ func TestUpdateScalingStatus_ScalingDown(t *testing.T) {
 	assertStatusEqual(t, rc, redkeyv1.StatusScalingDown)
 	assertConditionTrue(t, rc, redkeyv1.ConditionScalingDown)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingUp)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateScalingStatus_ScalingUp(t *testing.T) {
@@ -46,6 +47,7 @@ func TestUpdateScalingStatus_ScalingUp(t *testing.T) {
 	assertStatusEqual(t, rc, redkeyv1.StatusScalingUp)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingDown)
 	assertConditionTrue(t, rc, redkeyv1.ConditionScalingUp)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateScalingStatus_ScalingDown_Completed(t *testing.T) {
@@ -61,6 +63,7 @@ func TestUpdateScalingStatus_ScalingDown_Completed(t *testing.T) {
 	assertStatusEqual(t, rc, redkeyv1.StatusReady)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingDown)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingUp)
+	assertConditionTrue(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateScalingStatus_ScalingUp_Completed(t *testing.T) {
@@ -81,6 +84,7 @@ func TestUpdateScalingStatus_ScalingUp_Completed(t *testing.T) {
 	assertStatusEqual(t, rc, redkeyv1.StatusReady)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingDown)
 	assertConditionFalse(t, rc, redkeyv1.ConditionScalingUp)
+	assertConditionTrue(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateScalingStatus_ScalingUp_In_Progress(t *testing.T) {
@@ -120,6 +124,7 @@ func TestUpdateUpgradingStatus_Upgrading_Config_Not_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusReady)
 	assertConditionFalse(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionTrue(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Completed(t *testing.T) {
@@ -137,6 +142,7 @@ func TestUpdateUpgradingStatus_Upgrading_Completed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusReady)
 	assertConditionFalse(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionTrue(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Config_Changed(t *testing.T) {
@@ -158,6 +164,7 @@ func TestUpdateUpgradingStatus_Upgrading_Config_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Limits_Cpu_Changed(t *testing.T) {
@@ -179,6 +186,7 @@ func TestUpdateUpgradingStatus_Upgrading_Limits_Cpu_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Requests_Cpu_Changed(t *testing.T) {
@@ -200,6 +208,7 @@ func TestUpdateUpgradingStatus_Upgrading_Requests_Cpu_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Limits_Memory_Changed(t *testing.T) {
@@ -221,6 +230,7 @@ func TestUpdateUpgradingStatus_Upgrading_Limits_Memory_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Requests_Memory_Changed(t *testing.T) {
@@ -242,6 +252,7 @@ func TestUpdateUpgradingStatus_Upgrading_Requests_Memory_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestUpdateUpgradingStatus_Upgrading_Image_Changed(t *testing.T) {
@@ -262,6 +273,7 @@ func TestUpdateUpgradingStatus_Upgrading_Image_Changed(t *testing.T) {
 
 	assertStatusEqual(t, rc, redkeyv1.StatusUpgrading)
 	assertConditionTrue(t, rc, redkeyv1.ConditionUpgrading)
+	assertConditionFalse(t, rc, redkeyv1.ConditionReady)
 }
 
 func TestSetConditionTrue(t *testing.T) {

--- a/controllers/redkeycluster_manager.go
+++ b/controllers/redkeycluster_manager.go
@@ -65,7 +65,7 @@ func NewRedkeyClusterReconciler(mgr ctrl.Manager, maxConcurrentReconciles int, c
 func (r *RedkeyClusterReconciler) ReconcileClusterObject(ctx context.Context, req ctrl.Request, redkeyCluster *redkeyv1.RedkeyCluster) (ctrl.Result, error) {
 	var err error
 	var requeueAfter time.Duration = DefaultRequeueTimeout
-	currentStatus := redkeyCluster.Status
+	currentStatus := *redkeyCluster.Status.DeepCopy()
 
 	r.logInfo(redkeyCluster.NamespacedName(), "RedkeyCluster reconciler start", "status", redkeyCluster.Status.Status)
 
@@ -288,6 +288,12 @@ func (r *RedkeyClusterReconciler) reconcileStatusReady(ctx context.Context, redk
 		if err != nil {
 			r.logError(redkeyCluster.NamespacedName(), err, "Error when updating upgrading status")
 		}
+	}
+
+	// If the cluster is still in Ready status, update the condition to refresh the current
+	// kubernetes generation (ObserverGeneration).
+	if redkeyCluster.Status.Status == redkeyv1.StatusReady {
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 	}
 
 	// Requeue to check periodically the cluster is well formed and fix it if needed

--- a/controllers/redkeycluster_manager.go
+++ b/controllers/redkeycluster_manager.go
@@ -152,6 +152,7 @@ func (r *RedkeyClusterReconciler) reconcileStatusNew(redkeyCluster *redkeyv1.Red
 		redkeyCluster.Status.Nodes = make(map[string]*redkeyv1.RedisNode, 0)
 	}
 	redkeyCluster.Status.Status = redkeyv1.StatusInitializing
+	setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 	return requeue, DefaultRequeueTimeout
 }
 
@@ -253,6 +254,7 @@ func (r *RedkeyClusterReconciler) reconcileStatusConfiguring(ctx context.Context
 
 	// Redkey cluster is ok, moving to Ready status
 	redkeyCluster.Status.Status = redkeyv1.StatusReady
+	r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 
 	return requeue, DefaultRequeueTimeout
 }

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -120,11 +120,11 @@ func (r *RedkeyClusterReconciler) updateScalingStatus(ctx context.Context, redke
 		redkeyCluster.Status.Status = redkeyv1.StatusScalingDown
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingUp)
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionReady)
-		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingDown, fmt.Sprintf("Scaling down from %d to %d nodes", currSsetReplicas, redkeyCluster.Spec.Primaries))
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingDown, fmt.Sprintf("Scaling down from %d to %d primaries", currSsetReplicas, redkeyCluster.Spec.Primaries))
 	}
 	if realExpectedReplicas > currSsetReplicas {
 		redkeyCluster.Status.Status = redkeyv1.StatusScalingUp
-		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingUp, fmt.Sprintf("Scaling up from %d to %d nodes", currSsetReplicas, redkeyCluster.Spec.Primaries))
+		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingUp, fmt.Sprintf("Scaling up from %d to %d primaries", currSsetReplicas, redkeyCluster.Spec.Primaries))
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingDown)
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionReady)
 	}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -119,24 +119,28 @@ func (r *RedkeyClusterReconciler) updateScalingStatus(ctx context.Context, redke
 	if realExpectedReplicas < currSsetReplicas {
 		redkeyCluster.Status.Status = redkeyv1.StatusScalingDown
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingUp)
+		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionReady)
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingDown, fmt.Sprintf("Scaling down from %d to %d nodes", currSsetReplicas, redkeyCluster.Spec.Primaries))
 	}
 	if realExpectedReplicas > currSsetReplicas {
 		redkeyCluster.Status.Status = redkeyv1.StatusScalingUp
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionScalingUp, fmt.Sprintf("Scaling up from %d to %d nodes", currSsetReplicas, redkeyCluster.Spec.Primaries))
 		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingDown)
+		setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionReady)
 	}
 	if realExpectedReplicas == currSsetReplicas {
 		if redkeyCluster.Status.Status == redkeyv1.StatusScalingDown {
 			redkeyCluster.Status.Status = redkeyv1.StatusReady
 			redkeyCluster.Status.Substatus.Status = ""
 			setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingDown)
+			r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 		}
 		if redkeyCluster.Status.Status == redkeyv1.StatusScalingUp {
 			if len(redkeyCluster.Status.Nodes) == int(currSsetReplicas) {
 				redkeyCluster.Status.Status = redkeyv1.StatusReady
 				redkeyCluster.Status.Substatus.Status = ""
 				setConditionFalse(logger, redkeyCluster, redkeyv1.ConditionScalingUp)
+				r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 			}
 		}
 	}
@@ -169,6 +173,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 		r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", "Override changed")
 		redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Override changed")
+		setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 		return nil
 	}
 
@@ -192,6 +197,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 		if int(*(statefulSet.Spec.UpdateStrategy.RollingUpdate.Partition)) > 0 {
 			r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", "Previous upgrade not complete")
 			redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
+			setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 			return nil
 		}
 	}
@@ -223,12 +229,14 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 				r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", "Redis Labels Changed", "observed", observedLabels, "desired", desiredLabels)
 				redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 				r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Redis Labels Changed")
+				setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 				return nil
 			} else {
 				if value != val {
 					r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", "Redis Labels Changed", "observed", observedLabels, "desired", desiredLabels)
 					redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 					r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Redis Labels Changed")
+					setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 					return nil
 				}
 			}
@@ -252,6 +260,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 				r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", "Redis Labels Changed", "observed", observedLabels, "desired", desiredLabels)
 				redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 				r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Redis Labels Changed")
+				setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 				return nil
 			}
 		}
@@ -264,6 +273,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 		r.logInfo(redkeyCluster.NamespacedName(), "Cluster Upgrade Issued", "reason", reason)
 		redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Configuration in redis.conf is being updated")
+		setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 		return nil
 	}
 
@@ -284,6 +294,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 			redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 
 			r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, "Redis Resource Requests & Limits Changed")
+			setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 
 			return nil
 		}
@@ -298,6 +309,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 		redkeyCluster.Status.Status = redkeyv1.StatusUpgrading
 
 		r.setConditionTrue(redkeyCluster, redkeyv1.ConditionUpgrading, fmt.Sprintf("Redis Image Changed: observed %s desired %s", observedImage, desiredImage))
+		setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionReady)
 
 		return nil
 	}
@@ -309,6 +321,7 @@ func (r *RedkeyClusterReconciler) updateUpgradingStatus(ctx context.Context, red
 	if c != nil && c.Status == metav1.ConditionTrue {
 		setConditionFalse(r.getHelperLogger(redkeyCluster.NamespacedName()), redkeyCluster, redkeyv1.ConditionUpgrading)
 	}
+	r.setConditionTrue(redkeyCluster, redkeyv1.ConditionReady, "Redkey cluster is ready")
 
 	return nil
 }

--- a/test/e2e/redkey_suite_test.go
+++ b/test/e2e/redkey_suite_test.go
@@ -114,7 +114,6 @@ var _ = Describe("Redkey Operator & RedkeyCluster E2E", Label("operator", "clust
 			Entry("scale up 3 → 5", SpecTimeout(simpleTestDuration), int32(3), int32(5)),
 			Entry("scale down 5 → 3", SpecTimeout(simpleTestDuration), int32(5), int32(3)),
 			Entry("scale down 3 → 0", SpecTimeout(simpleTestDuration), int32(3), int32(0)),
-			Entry("scale up 0 → 3", SpecTimeout(simpleTestDuration), int32(0), int32(3)),
 		)
 	})
 


### PR DESCRIPTION
Closes #50 

The `Ready` condition has been added, created from the first reconciliation cycle (when the Redkey cluster enters the `Initializing` status). This condition will be `True` as long as the Redkey cluster is ready (fully initialized and configured, with no scaling or upgrade operations in progress). Otherwise, it will be `False`.

An event is generated when the `Ready` condition changes to `True`.

Some bugs were found during testing and have been fixed:

- LastTransitionTime was not updating on updates for all conditions. This bug has been fixed.
- When performing fast scalings, the corresponding condition remained with the value `True`, when it should have changed to `False`.

Additionally, Helm charts have been added for deploying Redkey Operator and Redkey cluster instances.

These charts were used for deployment testing to verify the behavior of the new `Ready` condition. It was deemed beneficial to include them in the project, so they are included in this Pull Request, along with the other changes.

The documentation has also been updated, including a `Quick Start` using these new Helm charts.