### PR TITLE
Allow empty `resources.requests` in Robin Deployment

### DIFF
--- a/controllers/robin.go
+++ b/controllers/robin.go
@@ -9,7 +9,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"maps"
-	"reflect"
 	"time"
 
 	redkeyv1 "github.com/inditextech/redkeyoperator/api/v1"
@@ -18,6 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -225,7 +225,7 @@ func (r *RedkeyClusterReconciler) overrideRobinDeployment(req ctrl.Request, redk
 	}
 
 	// Check if the override changes something in the original PodTemplateSpec
-	changed := !reflect.DeepEqual(podTemplateSpec.Labels, patchedPodTemplateSpec.Labels) || !reflect.DeepEqual(podTemplateSpec.Annotations, patchedPodTemplateSpec.Annotations) || !reflect.DeepEqual(podTemplateSpec.Spec, patchedPodTemplateSpec.Spec)
+	changed := !equality.Semantic.DeepEqual(podTemplateSpec.Labels, patchedPodTemplateSpec.Labels) || !equality.Semantic.DeepEqual(podTemplateSpec.Annotations, patchedPodTemplateSpec.Annotations) || !equality.Semantic.DeepEqual(podTemplateSpec.Spec, patchedPodTemplateSpec.Spec)
 
 	if changed {
 		r.logInfo(req.NamespacedName, "Detected robin deployment change")
@@ -266,12 +266,6 @@ func (r *RedkeyClusterReconciler) createRobinDeployment(req ctrl.Request, redkey
 	}
 
 	for i, container := range d.Spec.Template.Spec.Containers {
-		if container.Resources.Requests == nil {
-			d.Spec.Template.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("20m"),
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
-			}
-		}
 		if container.Resources.Limits == nil {
 			d.Spec.Template.Spec.Containers[i].Resources.Limits = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -481,13 +481,21 @@ func cleanPodTemplateSpecResult(result, override *corev1.PodTemplateSpec) {
 
 	// Copy the default resources of each container. This is because if not, merged.Spec.Containers[].Resources will be nil (override content)
 	for i, container := range result.Spec.Containers {
-		if container.Resources.Requests == nil {
-			result.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("20m"),
-				corev1.ResourceMemory: resource.MustParse("100Mi"),
+		// Ensure resources match the override, allowing removal of requests or limits
+		var overrideContainer *corev1.Container
+		for j := range override.Spec.Containers {
+			if override.Spec.Containers[j].Name == container.Name {
+				overrideContainer = &override.Spec.Containers[j]
+				break
 			}
 		}
-		if container.Resources.Limits == nil {
+
+		if overrideContainer != nil {
+			result.Spec.Containers[i].Resources = *overrideContainer.Resources.DeepCopy()
+		}
+
+		// Apply default limits if limits are still nil
+		if result.Spec.Containers[i].Resources.Limits == nil {
 			result.Spec.Containers[i].Resources.Limits = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
 				corev1.ResourceMemory: resource.MustParse("100Mi"),

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -1299,7 +1299,7 @@ func Test_ApplyPodTemplateSpecOverride(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "redis",
+							Name: "redis",
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -1290,6 +1290,70 @@ func Test_ApplyPodTemplateSpecOverride(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:     "Remove container resources requests",
+			original: *podTemplateSpec,
+			patch: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: defaultLabels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "redis",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: defaultLabels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "redis",
+							Image: "redis:6.0.15",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "client",
+									ContainerPort: 6379,
+								},
+								{
+									Name:          "gossip",
+									ContainerPort: 16379,
+								},
+							},
+							Command:        []string{"redis-server", "/conf/redis.conf"},
+							LivenessProbe:  CreateProbe(15, 5),
+							ReadinessProbe: CreateProbe(10, 5),
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/conf",
+								},
+							},
+						},
+					},
+					// Volumes should be nil here because override Spec.Volumes is empty/nil,
+					// and cleanPodTemplateSpecResult forces result Volumes to nil in this case.
+					Volumes: nil,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
 			name:     "Update container and volume",
 			original: *podTemplateSpec,
 			patch: corev1.PodTemplateSpec{

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -1343,10 +1343,6 @@ func Test_ApplyPodTemplateSpecOverride(t *testing.T) {
 									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
-								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
Closes #53 